### PR TITLE
Change ckan relationships

### DIFF
--- a/RP-1-ExpressInstall.netkan
+++ b/RP-1-ExpressInstall.netkan
@@ -13,12 +13,50 @@ resources:
   bugtracker: https://github.com/KSP-RO/RP-0/issues
   manual: https://github.com/KSP-RO/RP-0/wiki
 depends:
+  - any_of:
+    - name: RP-1
+    - name: RP-0
+    choice_help_text: Choose either the current version of RP-1 or the legacy version for continuing old saves
   - name: RP-1-ExpressInstall-Graphics
     choice_help_text: Select your graphics level. Low graphics will function on 8GB of RAM and requires the least powerful computer. Medium graphics looks better, but needs 16GB of RAM and a GTX 970/R9 390 or better. High graphics is best with 24GB+ (but might function on 16GB) and needs more modern graphics hardware (GTX 1070+/RX 5600+).
   - name: ModuleManager
+  - name: KSPCommunityFixes
+  - name: KSPBurst-Full
+  - name: ReStock
+  - name: ReStockPlus
+  - name: RSSDateTimeFormatter
+  - name: ROEngines
+  - name: ROHeatshields
+  - name: ROTanks
+  - name: ROCapsules
+  - name: ROSolar
+  - name: B9-PWings-Fork
+  - name: KSPWheel
+  - name: KerbalRenamer
+  - name: KSCSwitcher
+  - name: AtmosphereAutopilot
+  - name: ProceduralFairings
+  - name: ProceduralParts
+  - name: RCSBuildAid
+  - name: RealAntennas
+  - name: TestFlight
+  - name: TextureReplacer
+  - name: MechJeb2
+  - name: Waterfall
+  - name: HangerExtenderExtended
+  - name: ModularLaunchPads
+  - name: RealSolarSystem
+  - name: ConformalDecals
+  - name: Shabby
 recommends:
   - name: ROLoadingImages
   - name: EditorExtensionsRedux
   - name: KerbalAlarmClock
   - name: TransferWindowPlannerFork
   - name: LunarTransferPlanner
+conflicts:
+  - name: SmokeScreen-RO
+  - name: CustomBarnKit-RO
+  - name: SCANsat
+  - name: StageRecovery
+  - name: KerbalEngineerRedux

--- a/RP-1-ExpressInstall.netkan
+++ b/RP-1-ExpressInstall.netkan
@@ -13,12 +13,6 @@ resources:
   bugtracker: https://github.com/KSP-RO/RP-0/issues
   manual: https://github.com/KSP-RO/RP-0/wiki
 depends:
-  - any_of:
-    - name: RP-1
-    - name: RP-0
-    choice_help_text: Choose either the current version of RP-1 or the legacy version for continuing old saves
-  - name: RP-1-ExpressInstall-Graphics
-    choice_help_text: Select your graphics level. Low graphics will function on 8GB of RAM and requires the least powerful computer. Medium graphics looks better, but needs 16GB of RAM and a GTX 970/R9 390 or better. High graphics is best with 24GB+ (but might function on 16GB) and needs more modern graphics hardware (GTX 1070+/RX 5600+).
   - name: ModuleManager
   - name: KSPCommunityFixes
   - name: KSPBurst-Full
@@ -45,9 +39,15 @@ depends:
   - name: Waterfall
   - name: HangerExtenderExtended
   - name: ModularLaunchPads
-  - name: RealSolarSystem
   - name: ConformalDecals
   - name: Shabby
+  - name: RP-1-ExpressInstall-Graphics
+    choice_help_text: Select your graphics level. Low graphics will function on 8GB of RAM and requires the least powerful computer. Medium graphics looks better, but needs 16GB of RAM and a GTX 970/R9 390 or better. High graphics is best with 24GB+ (but might function on 16GB) and needs more modern graphics hardware (GTX 1070+/RX 5600+).
+  - any_of:
+    - name: RP-1
+    - name: RP-0
+    choice_help_text: Choose either the current version of RP-1 or the legacy version for continuing old saves
+  - name: RealSolarSystem
 recommends:
   - name: ROLoadingImages
   - name: EditorExtensionsRedux


### PR DESCRIPTION
I apologize for making a pull request that attempts to address two things at once:

First item:
I have added a couple conflicting packages to the express-install package. I blocked the outdated SmokeScreen-RO and CustomBarnKit-RO packages, as *if* a user has ckan compatiblity with older versions of ksp enabled, the express install will ask the user to pick between them and the up-to-date versions with the current metadata.
More controversially, I also blocked SCANsat, StageRecovery, and KerbalEngineerRedux. These mods are all of the mods on ["The Blacklist"](https://github.com/KSP-RO/RP-1/wiki/Extra-Mods-to-Consider#6-the-blacklist-mods-to-avoid) that are available on ckan. SCANsat and KER can both be made compatible with additional work after installation, but this falls into the realm of an "advanced user" who can use the non-express install if they want to use those mods.
It is more important, imo, to assure that the express install "just works" than to make it easy to customize. The [adjustments I made to the non-express install](https://github.com/KSP-RO/RP-1/pull/2205) make it much easier to use, so advanced users who do want to use those mods shouldn't find it too difficult to switch over from the express install.

Second item:
Currently, the express install package asks you to select a graphics preset, and it is the graphics preset metapackage that does the real "meat and potatoes" of installing ROEngines, ROTanks, etc. In conjunction with [this "sister" PR](https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics/pull/3), I would like to move the non-graphical dependencies out of the preset metapackages and into the express install itself. This makes the differences between the graphical presets easier to understand, makes it clearer to users what the express-install is actually doing, and makes maintaining the packages just a touch easier. The non-graphical dependencies between all 3 preset metapackages are already identical, so there are no changes to the actual end result of the installation.

I am happy to resubmit an edited PR if only one of the two changes is desired.