### PR TITLE
deleting choice between legacy and non-legacy since its incompatible now

### DIFF
--- a/RP-1-ExpressInstall.netkan
+++ b/RP-1-ExpressInstall.netkan
@@ -43,10 +43,6 @@ depends:
   - name: Shabby
   - name: RP-1-ExpressInstall-Graphics
     choice_help_text: Select your graphics level. Low graphics will function on 8GB of RAM and requires the least powerful computer. Medium graphics looks better, but needs 16GB of RAM and a GTX 970/R9 390 or better. High graphics is best with 24GB+ (but might function on 16GB) and needs more modern graphics hardware (GTX 1070+/RX 5600+).
-  - any_of:
-    - name: RP-1
-    - name: RP-0
-    choice_help_text: Choose either the current version of RP-1 or the legacy version for continuing old saves
   - name: RealSolarSystem
 recommends:
   - name: ROLoadingImages

--- a/RP-1-ExpressInstall.netkan
+++ b/RP-1-ExpressInstall.netkan
@@ -42,6 +42,7 @@ depends:
   - name: ConformalDecals
   - name: Shabby
   - name: RP-1-ExpressInstall-Graphics
+  - name: RP-1
     choice_help_text: Select your graphics level. Low graphics will function on 8GB of RAM and requires the least powerful computer. Medium graphics looks better, but needs 16GB of RAM and a GTX 970/R9 390 or better. High graphics is best with 24GB+ (but might function on 16GB) and needs more modern graphics hardware (GTX 1070+/RX 5600+).
   - name: RealSolarSystem
 recommends:


### PR DESCRIPTION
As per https://github.com/KSP-CKAN/CKAN-meta/pull/3206, all previous legacy RP-0 versions are incompatible by the time it gets to this option (because it's already selected RO 16x+) so might as well just remove it anyway. To be clear, this doesn't actually change anything, as now ckan just skips this option and goes straight to installing.