### PR TITLE
Mark KER 1.1.9.4 and lower as conflicting

### DIFF
--- a/RP-1-ExpressInstall.netkan
+++ b/RP-1-ExpressInstall.netkan
@@ -83,9 +83,12 @@ recommends:
   - name: KerbalAlarmClock
   - name: TransferWindowPlannerFork
   - name: LunarTransferPlanner
+  - name: KerbalEngineerRedux
+    min_version: v1.1.9.5
 conflicts:
   - name: SmokeScreen-RO
   - name: CustomBarnKit-RO
   - name: SCANsat
   - name: StageRecovery
   - name: KerbalEngineerRedux
+    max_version: v1.1.9.4

--- a/RP-1-ExpressInstall.netkan
+++ b/RP-1-ExpressInstall.netkan
@@ -83,8 +83,6 @@ recommends:
   - name: KerbalAlarmClock
   - name: TransferWindowPlannerFork
   - name: LunarTransferPlanner
-  - name: KerbalEngineerRedux
-    min_version: v1.1.9.5
 conflicts:
   - name: SmokeScreen-RO
   - name: CustomBarnKit-RO


### PR DESCRIPTION
KER 1.1.9.5 (https://github.com/jrbudda/KerbalEngineer/releases/tag/1.1.9.5) is finally compatible with RP-1, as the pull request that adds compatibility with Real Fuels has been merged. I'm not sure if this fixes the incorrect delta-v values, but it should fixes the crashes, and KER has many other features that other mods do not have.