### PR TITLE
Fix KER on ckan, add it to supports

### DIFF
--- a/RP-1-ExpressInstall.netkan
+++ b/RP-1-ExpressInstall.netkan
@@ -89,4 +89,4 @@ conflicts:
   - name: SCANsat
   - name: StageRecovery
   - name: KerbalEngineerRedux
-    max_version: v1.1.9.4
+    max_version: 1.1.9.4

--- a/RP-1-ExpressInstall.netkan
+++ b/RP-1-ExpressInstall.netkan
@@ -83,6 +83,9 @@ recommends:
   - name: KerbalAlarmClock
   - name: TransferWindowPlannerFork
   - name: LunarTransferPlanner
+supports:
+  - name: KerbalEngineerRedux
+    min_version: 1.1.9.5
 conflicts:
   - name: SmokeScreen-RO
   - name: CustomBarnKit-RO


### PR DESCRIPTION
As Hebaru [kindly pointed out](https://github.com/KSP-CKAN/CKAN/issues/4134), the reason that KER was still getting denied by express on ckan was because KER doesn't use "v" in its version numbers. Woops.

Also, add "supports KER", to at least let the user know that it is supported, even if it may not be recommended. (see discussion in https://github.com/KSP-RO/RP-1-ExpressInstall/pull/5)