### PR TITLE
Allow Test Lite to be chosen in express install

### DIFF
--- a/RP-1-ExpressInstall.netkan
+++ b/RP-1-ExpressInstall.netkan
@@ -53,7 +53,10 @@ depends:
     suppress_recommendations: true
   - name: RealAntennas
     suppress_recommendations: true
-  - name: TestFlight
+  - any_of:
+    - name: TestFlight
+    - name: TestLite
+    choice_help_text: TestFlight is recommended for a balanced RP-1 experience. Only use TestLite if you are fine with unrealistic reliability from engines.
     suppress_recommendations: true
   - name: TextureReplacer
     suppress_recommendations: true


### PR DESCRIPTION
As a user of Test Lite myself, it is slightly annoying that I need to avoid downloading the express install just so that I can use this mod instead of test flight. I understand that people want more realism out of their engines, but I am personally not able to put up with random failures from engines that, ultimately, I cannot control, and would usually just revert to launch anyway. I know that I am not the only one who feels this way.

However, I know that Test Flight is still widely recommended for balance reasons in RP-1, so I have made a note within ckan that recommends Test Flight over Test Lite. If this PR is merged, I will also make a note in the RP-1 wiki suggesting players to pick Test Flight when following the express install instructions.