### PR TITLE
Move CanaveralPads from required in high graphics to recommended across all express installs

### DIFF
--- a/RP-1-ExpressInstall.netkan
+++ b/RP-1-ExpressInstall.netkan
@@ -84,6 +84,7 @@ recommends:
   - name: TransferWindowPlannerFork
   - name: LunarTransferPlanner
   - name: KerbalFoundriesContinued
+  - name: CanaveralPads
 supports:
   - name: KerbalEngineerRedux
     min_version: 1.1.9.5


### PR DESCRIPTION
There are 2 reasons for this change:
- CanaveralPads is not a very taxing mod, so there is no real need to limit it only to the high graphics version of the express install.
- Not all High Graphics Express Install users are going to play at the KSC in Cape Canaveral, in which case having this mod required is a waste of resources and storage.

Should be done with: https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics/pull/5