### PR TITLE
Add deferred to express install

### DIFF
--- a/RP-1-ExpressInstall.netkan
+++ b/RP-1-ExpressInstall.netkan
@@ -69,6 +69,8 @@ depends:
     suppress_recommendations: true
   - name: Shabby
     suppress_recommendations: true
+  - name: Deferred
+    suppress_recommendations: true
   - name: RP-1-ExpressInstall-Graphics
     choice_help_text: Select your graphics level. Low graphics will function on 8GB of RAM and requires the least powerful computer. Medium graphics looks better, but needs 16GB of RAM and a GTX 970/R9 390 or better. High graphics is best with 24GB+ (but might function on 16GB) and needs more modern graphics hardware (GTX 1070+/RX 5600+).
   - any_of:


### PR DESCRIPTION
According to https://www.youtube.com/watch?v=Qn9h8GK7cY4, deferred gives better performance than stock, so there is no need to limit it to a certain graphics level.

Also remove planetshine from graphics express with https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics/pull/6

Fixes https://github.com/KSP-RO/RP-1-ExpressInstall/issues/7
Deferred is still listed as incompatible with Procedural Fairings and Procedural Parts (and therefore Express) due to https://github.com/KSP-RO/ProceduralFairings/issues/59, so this will remain as a draft PR (its barely an incompatibility though...)