### PR TITLE
Move KER from supports to suggests

### DIFF
--- a/RP-1-ExpressInstall.netkan
+++ b/RP-1-ExpressInstall.netkan
@@ -84,7 +84,7 @@ recommends:
   - name: TransferWindowPlannerFork
   - name: LunarTransferPlanner
   - name: KerbalFoundriesContinued
-supports:
+suggests:
   - name: KerbalEngineerRedux
     min_version: 1.1.9.5
 conflicts:


### PR DESCRIPTION
Supports doesn't match the CKAN [spec](https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md#supports), as it would imply that RP-1 adds something to KER that isn't present before. I would put it in suggests over recommend, as Mechjeb is more tightly integrated with RP-1 so KER is mostly seen as optional for some different UIs.